### PR TITLE
Add runtime config for OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm run slidev
 OpenAI API を使用してファイルの内容から `slides.md` を生成するスクリプトを用意しています。
 
 ```bash
-# 環境変数 OPENAI_API_KEY を設定して実行
+# 環境変数 `NITRO_OPENAI_API_KEY` を設定して実行
 npx tsx generateSlide.ts <対象ファイル>
 ```
 
@@ -39,5 +39,5 @@ npm run dev
 
 ## フロントエンドからの生成
 
-画面でファイルを選択すると **openaiでslidev用のファイルを作る** ボタンが有効になります。ボタンを押すと OpenAI の **Responses API** を使用して Markdown を生成し、ストリームで逐次表示されます。モデルは `o3` を使用しており、出力はテキストエリアで編集可能です。フロントエンドでも `openai-node` を利用してリクエストを送信します。開発サーバーを起動する際は `VITE_OPENAI_API_KEY` 環境変数に API キーを設定してください。
+画面でファイルを選択すると **openaiでslidev用のファイルを作る** ボタンが有効になります。ボタンを押すと OpenAI の **Responses API** を使用して Markdown を生成し、ストリームで逐次表示されます。モデルは `o3` を使用しており、出力はテキストエリアで編集可能です。フロントエンドでも `openai-node` を利用してリクエストを送信します。開発サーバーを起動する際は `.env` に `NITRO_OPENAI_API_KEY` を設定するか、環境変数 `NITRO_OPENAI_API_KEY` に API キーを指定してください。
 

--- a/composables/useOpenAI.ts
+++ b/composables/useOpenAI.ts
@@ -1,0 +1,7 @@
+import OpenAI from 'openai'
+
+export const useOpenAI = () => {
+  const config = useRuntimeConfig()
+  const apiKey = config.OPENAI_API_KEY as string | undefined
+  return new OpenAI({ apiKey, dangerouslyAllowBrowser: true })
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,8 +8,9 @@ export default defineNuxtConfig({
     strict: true
   },
   runtimeConfig: {
+    OPENAI_API_KEY: process.env.NITRO_OPENAI_API_KEY,
     public: {
-      OPENAI_API_KEY: process.env.OPENAI_API_KEY
+      OPENAI_API_KEY: process.env.NITRO_OPENAI_API_KEY
     }
   }
 })

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import OpenAI from 'openai'
+import { useOpenAI } from '~/composables/useOpenAI'
 
 const file = ref<File | null>(null)
 const error = ref('')
@@ -9,8 +9,8 @@ const result = ref('')
 const loading = ref(false)
 
 const config = useRuntimeConfig()
-const apiKey = config.public.OPENAI_API_KEY
-const openai = new OpenAI({ apiKey, dangerouslyAllowBrowser: true })
+const apiKey = config.OPENAI_API_KEY as string | undefined
+const openai = useOpenAI()
 
 function handleFileChange(e: Event) {
   const target = e.target as HTMLInputElement


### PR DESCRIPTION
## Summary
- add OPENAI_API_KEY to runtimeConfig
- access the key with `useRuntimeConfig` via `useOpenAI` composable
- document new environment variable usage in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d87ba6308832f86e0e98358812ed6