### PR TITLE
Switch scripts to Nuxt

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,25 @@
 npm run dev
 ```
 
+## ビルド
+
+```bash
+npm run build
+```
+
+## 本番プレビュー
+
+```bash
+npm run preview
+```
+
 ## slidev プレビュー
 
 ```bash
 npm run slidev
 ```
 
-`slides.md` を編集することでスライドを作成できます。Vue3 + TypeScript + Vite を使用しています。
+`slides.md` を編集することでスライドを作成できます。Vue3 + TypeScript + Nuxt 3 を使用しています。
 
 ## スライドの自動生成
 
@@ -39,5 +51,5 @@ npm run dev
 
 ## フロントエンドからの生成
 
-画面でファイルを選択すると **openaiでslidev用のファイルを作る** ボタンが有効になります。ボタンを押すと OpenAI の **Responses API** を使用して Markdown を生成し、ストリームで逐次表示されます。モデルは `o3` を使用しており、出力はテキストエリアで編集可能です。フロントエンドでも `openai-node` を利用してリクエストを送信します。開発サーバーを起動する際は `VITE_OPENAI_API_KEY` 環境変数に API キーを設定してください。
+画面でファイルを選択すると **openaiでslidev用のファイルを作る** ボタンが有効になります。ボタンを押すと OpenAI の **Responses API** を使用して Markdown を生成し、ストリームで逐次表示されます。モデルは `o3` を使用しており、出力はテキストエリアで編集可能です。フロントエンドでも `openai-node` を利用してリクエストを送信します。開発サーバーを起動する際は `OPENAI_API_KEY` 環境変数に API キーを設定してください。
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "nuxt dev",
     "build": "nuxt build",
+    "preview": "nuxt preview",
     "slidev": "slidev slides/slides.md"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- use Nuxt commands in npm scripts
- add preview script and clarify docs
- mention new OPENAI_API_KEY variable in docs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run slidev` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d87c420e0832f926eef7868686dc1