### PR TITLE
Fix OPENAI_API_KEY env reference

### DIFF
--- a/generateSlide.ts
+++ b/generateSlide.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import OpenAI from 'openai';
 
-const openai = new OpenAI();
+const openai = new OpenAI({ apiKey: process.env.NITRO_OPENAI_API_KEY });
 
 export async function generateSlides(filePath: string): Promise<string> {
   const ext = path.extname(filePath).toLowerCase();

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,9 +8,9 @@ export default defineNuxtConfig({
     strict: true
   },
   runtimeConfig: {
-    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    OPENAI_API_KEY: process.env.NITRO_OPENAI_API_KEY,
     public: {
-      OPENAI_API_KEY: process.env.OPENAI_API_KEY
+      OPENAI_API_KEY: process.env.NITRO_OPENAI_API_KEY
     }
   }
 })


### PR DESCRIPTION
## Summary
- read `NITRO_OPENAI_API_KEY` for runtime config
- pass `NITRO_OPENAI_API_KEY` to OpenAI client in CLI script

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_684e3e8c6660832fa01350cab9aaa762